### PR TITLE
Check if player is alive before dealing starve damage

### DIFF
--- a/functions.lua
+++ b/functions.lua
@@ -152,7 +152,7 @@ local function hunger_globaltimer(dtime)
 				end
 
 				-- or damage player by 1 hp if saturation is < 2 (of 30)
-				if tonumber(tab.lvl) < HUNGER_STARVE_LVL then
+				if tonumber(tab.lvl) < HUNGER_STARVE_LVL and hp > 0 then
 					player:set_hp(hp - HUNGER_STARVE)
 				end
 			end


### PR DESCRIPTION
When a player dies of starvation it happens that chat message "You died"
appears again and again if the player doesn't press Respawn button.

With this edit the damage dealing function checks if the player has life available ( hp > 0) 
before dealing damage, leading to not execute the function again and again after the player is dead.

It should solve problems with mods that prints death messages and drops inventory.
